### PR TITLE
allow for object definitions as filter arguments

### DIFF
--- a/src/parsers/directive.js
+++ b/src/parsers/directive.js
@@ -2,7 +2,7 @@ var _ = require('../util')
 var Cache = require('../cache')
 var cache = new Cache(1000)
 var argRE = /^[^\{\?]+$|^'[^']*'$|^"[^"]*"$/
-var filterTokenRE = /[^\s'"]+|'[^']+'|"[^"]+"/g
+var filterTokenRE = /[^\s'"{]+|'[^']+'|"[^"]+"|{[^}]+}/g
 
 /**
  * Parser state


### PR DESCRIPTION
I would like to propose a change to the filter token regex. This will allow for object definitions to be passed as a single argument to the filter. This will only work for shallow objects. For deep objects we would have to use a better parser.

e.g.:

```
{{ '%count% Pull Requests' | trans {count: count} }}
```

currently only this works:

```
{{ '%count% Pull Requests' | trans {count:count} }}
```
